### PR TITLE
Add V-CHANNEL docs and contract stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Unykorn NFT Marketplace
 
-This repository contains example Solidity smart contracts for an NFT marketplace with staking functionality. The contracts demonstrate how to list ERC‑731 tokens for sale and allow holders to stake their NFTs to earn rewards.
+This repository contains example Solidity contracts for an NFT marketplace with staking functionality. It has been extended with documentation and skeleton contracts for the proposed **V‑CHANNEL** system on Polygon Layer 1.
 
-## Contracts
+## Existing Contracts
 
 - `NFTMarketplace.sol` handles listing and purchasing NFTs with a configurable fee.
 - `NFTStaking.sol` allows users to stake their NFTs to earn ETH rewards over time.
 
-These contracts rely on [OpenZeppelin](https://openzeppelin.com/) libraries. They can be compiled and tested using tools such as Remix or Hardhat.
+## V‑CHANNEL Additions
 
+The `VCHANNEL_OVERVIEW.md` document provides an outline of a new entertainment and education stack built on Polygon. Contract stubs for the system are located under `contracts/`:
+
+- `GlacierMint.sol`
+- `TVVault.sol`
+- `PPVPaymentModule.sol`
+- `RoyaltyRouter.sol`
+- `EducationDAO.sol`
+
+These stubs serve as starting points for future development.

--- a/VCHANNEL_OVERVIEW.md
+++ b/VCHANNEL_OVERVIEW.md
@@ -1,0 +1,28 @@
+# V-CHANNEL on Polygon Layer 1
+
+This document outlines the proposed V-CHANNEL system built on Polygon L1 using Unykorn infrastructure as a base. The architecture combines entertainment, education, and commerce features with on-chain identity and compliance.
+
+## Key Contracts
+
+- **GlacierMint.sol** – ERC‑721/SBT registrar for `.tv` top-level domains. Responsible for minting TLDs and assigning vaults.
+- **TVVault.sol** – ERC‑6551 compliant vault contract controlling user media channels. Subdomains (e.g. `creator.tv`) map to individual vaults.
+- **PPVPaymentModule.sol** – Handles pay‑per‑view ticketing and unlock logic for encrypted streams.
+- **RoyaltyRouter.sol** – Routes streaming revenue to creators, investors, DAO affiliates, and tax vaults.
+- **EducationDAO.sol** – Governs community education initiatives and access to curriculum vaults.
+
+## High‑Level Flow
+
+1. **ERC‑4337** smart wallet login.
+2. Upon login, the user receives a `.tv` identity vault via **GlacierMint**.
+3. Content creators upload videos or streams to IPFS and attach them to their vault.
+4. **PPVPaymentModule** verifies ticket purchases and unlocks content.
+5. **RoyaltyRouter** splits revenue between stakeholders and the DAO.
+6. **EducationDAO** manages K‑12 courses and allows token‑gated access through vaults.
+
+## Deployment Targets
+
+- Polygon Mainnet
+- IPFS (Pinata) for media storage
+- Hardhat deployment scripts for contract deployment and registration
+
+This repository includes contract skeletons and documentation only. Further development is required to fully implement the system.

--- a/contracts/EducationDAO.sol
+++ b/contracts/EducationDAO.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/governance/Governor.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+
+/// @title EducationDAO
+/// @notice Basic Governor contract controlling education initiatives.
+contract EducationDAO is Governor, GovernorSettings, GovernorCountingSimple, GovernorVotes, GovernorVotesQuorumFraction {
+    constructor(ERC20Votes _token)
+        Governor("EducationDAO")
+        GovernorSettings(1 /* 1 block */, 45818 /* ~1 week */, 0)
+        GovernorVotes(_token)
+        GovernorVotesQuorumFraction(4)
+    {}
+
+    function votingDelay() public view override(Governor, GovernorSettings) returns (uint256) {
+        return super.votingDelay();
+    }
+
+    function votingPeriod() public view override(Governor, GovernorSettings) returns (uint256) {
+        return super.votingPeriod();
+    }
+
+    function quorum(uint256 blockNumber) public view override(Governor, GovernorVotesQuorumFraction) returns (uint256) {
+        return super.quorum(blockNumber);
+    }
+
+    function _getVotes(address account, uint256 blockNumber, bytes memory params)
+        internal
+        view
+        override(Governor, GovernorVotes)
+        returns (uint256)
+    {
+        return super._getVotes(account, blockNumber, params);
+    }
+
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public override(Governor) returns (uint256) {
+        return super.propose(targets, values, calldatas, description);
+    }
+
+    function _execute(uint256 proposalId, address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        internal override(Governor) {
+        super._execute(proposalId, targets, values, calldatas, descriptionHash);
+    }
+
+    function _cancel(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        internal override(Governor, GovernorSettings) returns (uint256)
+    {
+        return super._cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    function _executor() internal view override(Governor) returns (address) {
+        return super._executor();
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(Governor) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/GlacierMint.sol
+++ b/contracts/GlacierMint.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title GlacierMint - registrar for .tv vaults
+/// @notice Simplified ERC721 contract used to mint soulbound .tv domains that map to TVVaults.
+contract GlacierMint is ERC721URIStorage, Ownable {
+    uint256 public nextId;
+
+    constructor() ERC721("Glacier TV", "GLTV") {}
+
+    /// @notice Mint a new .tv top level domain to a user.
+    /// @dev For demonstration only. Real implementation would enforce soulbound behavior.
+    function mint(address to, string calldata uri) external onlyOwner returns (uint256) {
+        uint256 tokenId = ++nextId;
+        _mint(to, tokenId);
+        _setTokenURI(tokenId, uri);
+        return tokenId;
+    }
+}

--- a/contracts/PPVPaymentModule.sol
+++ b/contracts/PPVPaymentModule.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title PPVPaymentModule
+/// @notice Simplified pay-per-view unlock logic.
+contract PPVPaymentModule {
+    event AccessGranted(address indexed user, uint256 contentId);
+
+    mapping(uint256 => uint256) public ticketPrice;
+    mapping(uint256 => mapping(address => bool)) public hasAccess;
+
+    /// @notice Set the ticket price for a given contentId.
+    function setPrice(uint256 contentId, uint256 price) external {
+        ticketPrice[contentId] = price;
+    }
+
+    /// @notice Purchase access to content.
+    function buyTicket(uint256 contentId) external payable {
+        uint256 price = ticketPrice[contentId];
+        require(price > 0, "No ticket available");
+        require(msg.value >= price, "Insufficient payment");
+
+        hasAccess[contentId][msg.sender] = true;
+        emit AccessGranted(msg.sender, contentId);
+    }
+}

--- a/contracts/RoyaltyRouter.sol
+++ b/contracts/RoyaltyRouter.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title RoyaltyRouter
+/// @notice Splits incoming revenue between recipients based on basis points.
+contract RoyaltyRouter {
+    using Address for address payable;
+
+    struct Recipient {
+        address payable account;
+        uint96 bps; // out of 10,000
+    }
+
+    Recipient[] public recipients;
+
+    constructor(Recipient[] memory _recipients) {
+        uint256 totalBps;
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            recipients.push(_recipients[i]);
+            totalBps += _recipients[i].bps;
+        }
+        require(totalBps == 10000, "Invalid bps");
+    }
+
+    receive() external payable {
+        uint256 amount = msg.value;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            uint256 share = (amount * recipients[i].bps) / 10000;
+            recipients[i].account.sendValue(share);
+        }
+    }
+}

--- a/contracts/TVVault.sol
+++ b/contracts/TVVault.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title TVVault
+/// @notice ERC-6551 style vault for controlling streaming channels and media.
+contract TVVault {
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+
+    /// @notice Simple example allowing deposit of ERC721 tokens to the vault.
+    function depositERC721(address token, uint256 tokenId) external onlyOwner {
+        IERC721(token).transferFrom(msg.sender, address(this), tokenId);
+    }
+
+    /// @notice Withdraw an ERC721 token from the vault.
+    function withdrawERC721(address token, uint256 tokenId, address to) external onlyOwner {
+        IERC721(token).transferFrom(address(this), to, tokenId);
+    }
+}


### PR DESCRIPTION
## Summary
- outline V-CHANNEL architecture in `VCHANNEL_OVERVIEW.md`
- add skeleton contracts for GlacierMint, TVVault, PPVPaymentModule, RoyaltyRouter and EducationDAO
- update README with references to V-CHANNEL documentation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884e2f8c4d88329976e20b7100fe9c7