### PR TITLE
Add core FTH tokenization contracts and deployment scripts

### DIFF
--- a/contracts/BaseRevenueToken.sol
+++ b/contracts/BaseRevenueToken.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title Base token that can distribute stablecoin revenues pro rata
+abstract contract BaseRevenueToken is ERC20, Ownable {
+    IERC20 public stablecoin;
+    address public revenueRouter;
+
+    uint256 public magnifiedDividendPerShare;
+    mapping(address => uint256) public withdrawnDividends;
+    uint256 internal constant MAGNITUDE = 1e18;
+
+    constructor(string memory name_, string memory symbol_, address stable_) ERC20(name_, symbol_) {
+        stablecoin = IERC20(stable_);
+    }
+
+    function setRevenueRouter(address router) external onlyOwner {
+        revenueRouter = router;
+    }
+
+    /// @dev Called by the revenue router after transferring stablecoin
+    function distribute(uint256 amount) external {
+        require(msg.sender == revenueRouter, "not router");
+        require(totalSupply() > 0, "no supply");
+        magnifiedDividendPerShare += (amount * MAGNITUDE) / totalSupply();
+    }
+
+    function claim() public {
+        uint256 withdrawable = ((magnifiedDividendPerShare * balanceOf(msg.sender)) / MAGNITUDE) - withdrawnDividends[msg.sender];
+        withdrawnDividends[msg.sender] += withdrawable;
+        if (withdrawable > 0) {
+            stablecoin.transfer(msg.sender, withdrawable);
+        }
+    }
+}
+

--- a/contracts/ComplianceRegistry.sol
+++ b/contracts/ComplianceRegistry.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Simple KYC/AML whitelist
+contract ComplianceRegistry is Ownable {
+    mapping(address => bool) private _whitelisted;
+
+    event Whitelisted(address indexed account);
+    event Removed(address indexed account);
+
+    function add(address account) external onlyOwner {
+        _whitelisted[account] = true;
+        emit Whitelisted(account);
+    }
+
+    function remove(address account) external onlyOwner {
+        _whitelisted[account] = false;
+        emit Removed(account);
+    }
+
+    function isWhitelisted(address account) external view returns (bool) {
+        return _whitelisted[account];
+    }
+}
+

--- a/contracts/FTHCarbonToken.sol
+++ b/contracts/FTHCarbonToken.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Tokenized carbon credits
+contract FTHCarbonToken is ERC1155, Ownable {
+    constructor() ERC1155("") {}
+
+    function mint(address to, uint256 id, uint256 amount, bytes memory data) external onlyOwner {
+        _mint(to, id, amount, data);
+    }
+}
+

--- a/contracts/FTHDebtToken.sol
+++ b/contracts/FTHDebtToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./BaseRevenueToken.sol";
+
+/// @title Senior debt token with revenue distribution
+contract FTHDebtToken is BaseRevenueToken {
+    constructor(address stablecoin) BaseRevenueToken("FTH Debt Token", "FTHD", stablecoin) {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+}
+

--- a/contracts/FTHEquityToken.sol
+++ b/contracts/FTHEquityToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./BaseRevenueToken.sol";
+
+/// @title Equity token with dividend distribution
+contract FTHEquityToken is BaseRevenueToken {
+    constructor(address stablecoin) BaseRevenueToken("FTH Equity Token", "FTHE", stablecoin) {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+}
+

--- a/contracts/MockStablecoin.sol
+++ b/contracts/MockStablecoin.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Simple mintable ERC20 used as stablecoin
+contract MockStablecoin is ERC20, Ownable {
+    constructor() ERC20("MockStable", "MSC") {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+}
+

--- a/contracts/RevenueRouter.sol
+++ b/contracts/RevenueRouter.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./FTHDebtToken.sol";
+import "./FTHEquityToken.sol";
+import "./ComplianceRegistry.sol";
+
+/// @title Routes incoming revenues to debt, equity and reserves
+contract RevenueRouter {
+    IERC20 public stablecoin;
+    FTHDebtToken public debt;
+    FTHEquityToken public equity;
+    ComplianceRegistry public compliance;
+
+    address public reserveWallet;
+    uint256 public debtShare;
+    uint256 public equityShare;
+    uint256 public reserveShare;
+
+    constructor(
+        address _stablecoin,
+        address _debt,
+        address _equity,
+        address _reserveWallet,
+        address _compliance,
+        uint256 _debtShare,
+        uint256 _equityShare,
+        uint256 _reserveShare
+    ) {
+        stablecoin = IERC20(_stablecoin);
+        debt = FTHDebtToken(_debt);
+        equity = FTHEquityToken(_equity);
+        reserveWallet = _reserveWallet;
+        compliance = ComplianceRegistry(_compliance);
+        debtShare = _debtShare;
+        equityShare = _equityShare;
+        reserveShare = _reserveShare;
+    }
+
+    function distribute(uint256 amount) external {
+        require(compliance.isWhitelisted(msg.sender), "not compliant");
+        require(stablecoin.transferFrom(msg.sender, address(this), amount), "transfer failed");
+
+        uint256 toDebt = (amount * debtShare) / 100;
+        uint256 toEquity = (amount * equityShare) / 100;
+        uint256 toReserve = (amount * reserveShare) / 100;
+
+        stablecoin.transfer(address(debt), toDebt);
+        stablecoin.transfer(address(equity), toEquity);
+        stablecoin.transfer(reserveWallet, toReserve);
+
+        debt.distribute(toDebt);
+        equity.distribute(toEquity);
+    }
+}
+

--- a/contracts/VaultManager.sol
+++ b/contracts/VaultManager.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Minimal registry for asset vaults
+contract VaultManager is Ownable {
+    mapping(uint256 => address) public vaults;
+    event VaultRegistered(uint256 indexed assetId, address vault);
+
+    function registerVault(uint256 assetId, address vault) external onlyOwner {
+        vaults[assetId] = vault;
+        emit VaultRegistered(assetId, vault);
+    }
+}
+

--- a/scripts/deployFTH.js
+++ b/scripts/deployFTH.js
@@ -1,0 +1,54 @@
+const hre = require("hardhat");
+
+async function main() {
+  const [deployer] = await hre.ethers.getSigners();
+  console.log("Deploying with", deployer.address);
+
+  const MockStablecoin = await hre.ethers.getContractFactory("MockStablecoin");
+  const stable = await MockStablecoin.deploy();
+  await stable.deployed();
+  await stable.mint(deployer.address, hre.ethers.utils.parseEther("1000000"));
+
+  const ComplianceRegistry = await hre.ethers.getContractFactory("ComplianceRegistry");
+  const compliance = await ComplianceRegistry.deploy();
+  await compliance.deployed();
+  await compliance.add(deployer.address);
+
+  const FTHDebtToken = await hre.ethers.getContractFactory("FTHDebtToken");
+  const debt = await FTHDebtToken.deploy(stable.address);
+  await debt.deployed();
+
+  const FTHEquityToken = await hre.ethers.getContractFactory("FTHEquityToken");
+  const equity = await FTHEquityToken.deploy(stable.address);
+  await equity.deployed();
+
+  const RevenueRouter = await hre.ethers.getContractFactory("RevenueRouter");
+  const router = await RevenueRouter.deploy(
+    stable.address,
+    debt.address,
+    equity.address,
+    deployer.address,
+    compliance.address,
+    50,
+    40,
+    10
+  );
+  await router.deployed();
+
+  await debt.setRevenueRouter(router.address);
+  await equity.setRevenueRouter(router.address);
+  await debt.mint(deployer.address, hre.ethers.utils.parseEther("1000"));
+  await equity.mint(deployer.address, hre.ethers.utils.parseEther("1000"));
+
+  console.log("Stablecoin:", stable.address);
+  console.log("Compliance:", compliance.address);
+  console.log("Debt token:", debt.address);
+  console.log("Equity token:", equity.address);
+  console.log("Revenue router:", router.address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/scripts/distributeRevenue.js
+++ b/scripts/distributeRevenue.js
@@ -1,0 +1,21 @@
+const hre = require("hardhat");
+
+async function main() {
+  const [caller] = await hre.ethers.getSigners();
+  const routerAddress = process.env.ROUTER;
+  const stableAddress = process.env.STABLE;
+
+  const router = await hre.ethers.getContractAt("RevenueRouter", routerAddress);
+  const stable = await hre.ethers.getContractAt("MockStablecoin", stableAddress);
+
+  const amount = hre.ethers.utils.parseEther("1000");
+  await stable.approve(router.address, amount);
+  await router.distribute(amount);
+  console.log("Distributed", hre.ethers.utils.formatEther(amount), "stablecoins");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
## Summary
- implement FTH debt, equity, and carbon token contracts
- add revenue router with compliance registry and vault manager
- create Hardhat deployment and distribution scripts

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list. Proxy response (403) !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_68aac9848ed08329bd8ed8bc34438108