### PR TITLE
Add Slither static analysis setup

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,23 @@
+name: Slither
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/**'
+      - 'package.json'
+      - '.github/workflows/slither.yml'
+
+jobs:
+  slither:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install slither-analyzer
+      - run: npm install
+      - run: npm run slither

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ This repository contains example Solidity smart contracts for an NFT marketplace
    ```
 
 Copy `.env.template` to `.env` and fill in your RPC URL and deployer private key for network configuration.
+
+## Static Analysis
+
+Slither is used to run static analysis on the Solidity contracts.
+
+1. Install Slither:
+   ```bash
+   pip install slither-analyzer
+   ```
+2. Run the analysis:
+   ```bash
+   npm run slither
+   ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This repository contains example Solidity smart contracts for an NFT marketplace with staking functionality. The contracts demonstrate how to list ERC‑731 tokens for sale and allow holders to stake their NFTs to earn rewards.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "slither": "slither ./contracts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm script to run Slither static analysis
- document Slither usage and add CI workflow

## Testing
- `slither --version`
- `npm run slither` *(fails: Solidity version not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aacef07e788329b93e2a0dced9fb23