### PR TITLE
Add .mars TLD contracts and deployment scripts

### DIFF
--- a/.claude-flow/tasks/.mars-superstack.md
+++ b/.claude-flow/tasks/.mars-superstack.md
@@ -1,0 +1,122 @@
+SYSTEM ROLE
+You are the Lead Architect AI for the .mars sovereign namespace under the Unykorn/GlacierMint stack. Build a production-grade, compliance-aware, chain-agnostic system that mints and governs .mars TLD + subdomains and powers soulbound ERC-6551 wallets, vault vaults, token minting, and real-world asset onboarding. Ship an auditable, runnable repo with scripts, tests, and docs.
+
+PRIMARY OBJECTIVE
+Design and scaffold the most capable yet minimal-to-run .mars stack that an operator can deploy in hours, then scale to institutions. Optimize for correctness, security, composability, and compliance.
+
+OUTPUT REQUIREMENTS
+• A complete monorepo with:
+  - /contracts (Solidity): TLD, Controller, Resolver, Registry adapter, ERC-6551 account + registry, Vaults, Token factories, Compliance modules, Oracle adapters
+  - /deploy (Foundry/Hardhat scripts): one-shot deployment, param sync from .3, subdomain reserves (dao.mars, gov.mars, vault.mars, id.mars)
+  - /packages/sdk (TypeScript): typed client (ethers + viem), subdomain mint, vault ops, token mint, compliance attest, PoR hooks
+  - /agents (JS/TS): FlowAgent, ComplianceAgent, OracleAgent (Chainlink + internal), RWA Intake Agent, MRV Agent for sustainability assets
+  - /apps/portal (React+Vite): operator console (TLD admin, registry sync, mint flows, KYC/KYB checklist, PoR dashboard)
+  - /docs: ARCHITECTURE.md, COMPLIANCE.md, RWA-PLAYBOOK.md, RUNBOOK.md, API.md
+  - CI: Foundry tests, slither/solhint, gas snapshots, typechain build, coverage gate
+• Provide env templates, Makefile, and a single command to deploy on Polygon/Ethereum testnet, then mainnet.
+
+SCOPE & MODULES
+1) TLD & Registry
+   - GlacierMint-compatible `.mars` TLD (ERC-721 root), hash keccak256(".mars")
+   - Mirror all params from `.3` (resolver, controller, fee model, compliance module, 6551 impl)
+   - Subdomain NFTs (ERC-721) with TokenBound (ERC-6551) accounts auto-bound at mint
+   - Leasing + renewal (annual), grace periods, reserve list, premium pricing hooks
+
+2) Identity & Wallets (Soulbound “bad-ass” 6551)
+   - ERC-6551 minimal proxy accounts; enforce SOULBOUND on TLD + identity NFTs (non-transferable except via guardian recover)
+   - Guardian/social recovery (EIP-4337 compatible), session keys, rate-limited withdrawals, allowlist ops
+   - Roles: OWNER, OPERATOR, COMPLIANCE_OFFICER, ORACLE_SIGNER
+
+3) Vaults & Asset Containers
+   - ERC-6551 “VaultAccount” template to custody tokens, RWAs, receipts, sub-NFTs
+   - Plug-in modules: FeeRouter, RoyaltyRouter (ERC-2981), TaxWithholding, Freeze/Seize (court order or DAO vote), TimeLock
+
+4) Token Factories
+   - Utility/Gov: ERC-20 & 20Permit; optional Fee-On-Transfer with compliance hooks
+   - Multi-asset: ERC-1155 for baskets (e.g., energy credits, certificates)
+   - Securities: ERC-1400/3643-style partitioned shares (whitelist, tranches, lock-up, transfer restrictions, investor caps)
+   - Bond/Sukuk templates: coupon schedules, profit-sharing, asset-linked payouts, Sharia screens pluggable
+
+5) RWA Onboarding
+   - Intake schema (JSON): identity, asset docs, appraisal, liens, jurisdiction, ESG/MRV data
+   - IPFS/Arweave notarization; PGP signature bundle; on-chain CID anchors
+   - Chainlink Proof-of-Reserves adapter + custom OracleAgent for off-chain attestations
+   - Title/escrow flows: mint RWA-NFT → wrap in ERC-6551 vault → issue fractions (ERC-1400/1155) with compliance gating
+
+6) Compliance Layer (GLOBAL)
+   - RegLogic module: KYC/KYB attest (soulbound badges), FATF Travel Rule fields, sanctions lists, geo-fencing
+   - ISO 20022 event emitters (PACS/CAMT subsets) as on-chain logs + off-chain webhooks
+   - Transfer pre-checks: ruleSets (US Reg D/Reg S, EU MiCA, UK, CH), investor eligibility, holding periods
+   - Audit trail export (JSON/CSV/PDF) with deterministic hashes
+
+7) Interop & Settlement
+   - LayerZero or Axelar bridge adapter with compliance pre-flight
+   - Oracle adapters (Chainlink/Pyth) for FX, commodities, energy
+   - Optional CBDC/RLN bridge stub interface
+
+8) Governance
+   - DAO contracts: TLD policy votes (fees, reserves, compliance rules), emergency pause, court-order executor
+   - Snapshot-compatible strategy + on-chain timelock executor
+
+9) Security & Quality
+   - AccessControl, Pausable, ReentrancyGuard; upgradability via UUPS with guardian veto
+   - Full Foundry tests: unit + invariant + fuzz; minimal reproducible gas profile
+
+API & COMMANDS (OPERATOR UX)
+• make up
+  - installs toolchain (node, foundry), builds contracts, generates typechain
+• make test
+  - runs slither/solhint + foundry tests + coverage
+• make devnet
+  - spins local chain, deploys full stack, seeds sample assets (.env overrides)
+• make deploy-testnet / make deploy-mainnet
+  - runs one-shot scripts: deploy TLD → apply params from .3 → reserve names → publish CIDs → print addresses
+• sdk usage examples in /examples: mint subdomain, mint vault, mint token (20/1155/1400), attach compliance, publish PoR
+
+KEY INTERFACES (Solidity—exact signatures the repo must implement)
+• ITLDLike.applyParams(address resolver, address controller, address feeModel, address compliance, address tbaImpl)
+• IController.mint(address to, string label, string tld) returns (uint256 tokenId)
+• ISubdomainResolver.setRecords(tokenId, bytes[] records)
+• ICompliance.checkTransfer(address from, address to, address asset, uint256 id, uint256 amount) returns (bool ok, bytes32 reason)
+• IVaultAccount.execute(bytes targetCall) restricted(OPERATOR | OWNER | POLICY)
+• IOracleAgent.attest(bytes32 schemaId, bytes payload, bytes signature) returns (bytes32 attestationId)
+• IProofOfReserves.report(bytes32 assetId, uint256 value, uint256 timestamp, bytes oracleSig)
+
+CONFIG VARIABLES (fill from .env)
+GLACIER_REGISTRY=0x...
+DOT3_TLD=0x...(for param mirroring)
+POLYGON_RPC_URL=...
+ETH_RPC_URL=...
+CHAINLINK_FEEDS={fx:..., commodity:..., energy:...}
+LAYERZERO_ENDPOINT=0x...
+PGP_PUBKEY=-----BEGIN PGP PUBLIC KEY BLOCK-----...
+
+NON-FUNCTIONAL TARGETS
+• Gas-aware design; modular hooks (minimal overhead when disabled)
+• Deterministic build; reproducible deployments with salts
+• Clean separation: core vs policy vs jurisdiction modules
+
+DELIVERABLE CHECKLIST
+[ ] Deployable contracts with addresses saved to /deploy/addresses.json
+[ ] One-shot deployment script succeeds on testnet (print all addresses)
+[ ] 90%+ unit coverage; ≥10 invariant tests; ≥5 fuzz tests per critical module
+[ ] CI green: lint, typecheck, tests, coverage, build
+[ ] Operator Portal runs: can reserve subdomains, mint identity, mint vault, mint tokens, attach compliance, publish PoR
+[ ] Docs: runbook for ops, architecture diagrams (mermaid), RWA onboarding playbook, API examples
+[ ] Security: list of assumptions/threats, admin keys & recovery plan, pause procedure
+
+STYLE & GUARDRAILS
+• Prefer OpenZeppelin contracts; explicit AccessControl roles
+• Upgradability via UUPS only when strictly necessary; otherwise immutable
+• All external calls checked; no tx-origin auth; events for every state change
+• Avoid custom assembly unless justified with tests and comments
+
+INITIAL RESERVED SUBDOMAINS
+dao.mars, gov.mars, vault.mars, id.mars, oracle.mars, court.mars, bridge.mars, rwa.mars, energy.mars, carbon.mars
+
+END STATE
+Return a fully scaffolded repo (tree + files) ready to `make devnet` and `make deploy-testnet`. Include seed scripts that mint:
+• a soulbound identity (id.mars) bound to a 6551 wallet,
+• a vault.mars ERC-6551 account holding a sample RWA-NFT,
+• a governance ERC-20 and an ERC-1400 security with Reg D rules,
+• proof-of-reserves sample attestation wired to the dashboard.

--- a/mars-tld/.env.example
+++ b/mars-tld/.env.example
@@ -1,0 +1,15 @@
+# chain + keys
+# Generate a fresh key: openssl rand -hex 32
+PRIVATE_KEY=0x0123456789012345678901234567890123456789012345678901234567890123
+RPC_URL=https://polygon-rpc.com
+
+# registry (existing from .3)
+GLACIER_REGISTRY=0xYourRegistry
+
+# filled after deploy
+MARS_TLD=0xDeployedMarsTLD
+
+# for subdomain mint
+CONTROLLER=0xControllerFromDot3
+RECIPIENT=0xRecipient
+LABEL=dao

--- a/mars-tld/Makefile
+++ b/mars-tld/Makefile
@@ -1,0 +1,17 @@
+include .env
+export
+
+build:
+	forge build
+
+deploy:
+	forge script scripts/04_one_shot_deploy.s.sol:OneShotMars \
+	 --rpc-url $$RPC_URL --broadcast -vvvv --legacy
+
+apply:
+	forge script scripts/02_apply_params_from_dot3.s.sol:ApplyParamsFromDot3 \
+	 --rpc-url $$RPC_URL --broadcast -vvvv
+
+mint:
+	forge script scripts/03_mint_subdomain.s.sol:MintSubdomain \
+	 --rpc-url $$RPC_URL --broadcast -vvvv

--- a/mars-tld/README.md
+++ b/mars-tld/README.md
@@ -1,0 +1,40 @@
+# .mars TLD (GlacierMint / Unykorn)
+
+Deploy `.mars` mirroring `.3` parameters.
+
+## 0) Environment
+```bash
+cp .env.example .env
+# generate a fresh PRIVATE_KEY and prefix with 0x
+openssl rand -hex 32
+```
+Fill `PRIVATE_KEY`, `RPC_URL`, and `GLACIER_REGISTRY` in `.env`.
+
+## 1) Install Foundry
+```bash
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
+Alternatively install via Homebrew or Docker if curl is blocked.
+
+## 2) Build and deploy
+```bash
+cd mars-tld
+make build      # forge build
+make deploy     # one-shot deploy script
+```
+`make deploy` runs `scripts/04_one_shot_deploy.s.sol:OneShotMars` which deploys the TLD, applies `.3` params, and mints reserved labels.
+
+## 3) Manual operations
+Inspect `.3` params:
+```bash
+forge script scripts/00_read_dot3_params.s.sol:ReadDot3 --rpc-url $RPC_URL
+```
+Apply parameters separately:
+```bash
+forge script scripts/02_apply_params_from_dot3.s.sol:ApplyParamsFromDot3 --rpc-url $RPC_URL --broadcast -vvvv
+```
+Mint a subdomain:
+```bash
+forge script scripts/03_mint_subdomain.s.sol:MintSubdomain --rpc-url $RPC_URL --broadcast -vvvv
+```

--- a/mars-tld/contracts/IControllerLike.sol
+++ b/mars-tld/contracts/IControllerLike.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IControllerLike {
+    // Generic mint; change signature if your controller differs
+    function mint(address to, string calldata label, string calldata tld) external returns (uint256 tokenId);
+}

--- a/mars-tld/contracts/IGlacierRegistry.sol
+++ b/mars-tld/contracts/IGlacierRegistry.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IGlacierRegistry {
+    // Adjust to your real registry ABI; this matches the read you used for `.3`
+    function tldInfo(bytes32 tldHash) external view returns (
+        address tldContract,
+        address resolver,
+        address controller,
+        address feeModel,
+        address compliance,
+        address tbaImpl
+    );
+
+    // If your registry requires explicit registration, uncomment and use this:
+//  function registerTLD(bytes32 tldHash, address tld) external;
+}

--- a/mars-tld/contracts/ITLDLike.sol
+++ b/mars-tld/contracts/ITLDLike.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ITLDLike {
+    function tldName() external view returns (string memory);
+    function applyParams(
+        address _resolver,
+        address _controller,
+        address _feeModel,
+        address _compliance,
+        address _tbaImpl
+    ) external;
+}

--- a/mars-tld/contracts/MarsTLD.sol
+++ b/mars-tld/contracts/MarsTLD.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./ITLDLike.sol";
+
+/**
+ * @title MarsTLD
+ * @dev Minimal TLD wrapper matching your .3 pattern.
+ *      Params (resolver/controller/fee/compliance/tba) are set via applyParams().
+ */
+contract MarsTLD is ITLDLike {
+    string public constant NAME = ".mars";
+
+    address public immutable registry;
+    address public resolver;
+    address public controller;
+    address public feeModel;
+    address public compliance;
+    address public tbaImpl; // ERC-6551 impl
+
+    event ParamsApplied(address resolver, address controller, address feeModel, address compliance, address tbaImpl);
+
+    constructor(address _registry) {
+        require(_registry != address(0), "registry=0");
+        registry = _registry;
+    }
+
+    function tldName() external pure returns (string memory) { return NAME; }
+
+    function applyParams(
+        address _resolver,
+        address _controller,
+        address _feeModel,
+        address _compliance,
+        address _tbaImpl
+    ) external {
+        resolver   = _resolver;
+        controller = _controller;
+        feeModel   = _feeModel;
+        compliance = _compliance;
+        tbaImpl    = _tbaImpl;
+        emit ParamsApplied(_resolver, _controller, _feeModel, _compliance, _tbaImpl);
+    }
+}

--- a/mars-tld/foundry.toml
+++ b/mars-tld/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+solc = "0.8.20"
+optimizer = true
+optimizer_runs = 1_000
+fs_permissions = [{ access = "read", path = "./" }]
+
+[fmt]
+line_length = 100
+tab_width = 4

--- a/mars-tld/metadata/subdomain.example.json
+++ b/mars-tld/metadata/subdomain.example.json
@@ -1,0 +1,8 @@
+{
+  "name": "dao.mars",
+  "purpose": "Governance domain bound to ERC-6551 vault",
+  "tld": ".mars",
+  "controller": "AUTO-FROM-.3",
+  "resolver": "AUTO-FROM-.3",
+  "compliance": "AUTO-FROM-.3"
+}

--- a/mars-tld/metadata/tld.json
+++ b/mars-tld/metadata/tld.json
@@ -1,0 +1,7 @@
+{
+  "name": ".mars",
+  "description": "Sovereign AI & RWA namespace for space economy assets, agents, and DAOs.",
+  "issuer": "Unykorn GlacierMint Registry",
+  "created": "2025-08-24T00:00:00Z",
+  "proof": "ipfs://TO-BE-FILLED"
+}

--- a/mars-tld/scripts/00_read_dot3_params.s.sol
+++ b/mars-tld/scripts/00_read_dot3_params.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/IGlacierRegistry.sol";
+
+contract ReadDot3 is Script {
+    function run() external view {
+        address REG = vm.envAddress("GLACIER_REGISTRY");
+        bytes32 DOT3 = keccak256(abi.encodePacked(".3"));
+        ( ,address resolver,address controller,address fee,address comp,address tba) =
+            IGlacierRegistry(REG).tldInfo(DOT3);
+
+        console2.log("Resolver:   ", resolver);
+        console2.log("Controller: ", controller);
+        console2.log("FeeModel:   ", fee);
+        console2.log("Compliance: ", comp);
+        console2.log("TBA Impl:   ", tba);
+    }
+}

--- a/mars-tld/scripts/01_deploy_mars.s.sol
+++ b/mars-tld/scripts/01_deploy_mars.s.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/MarsTLD.sol";
+
+contract DeployMars is Script {
+    function run() external {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address REG = vm.envAddress("GLACIER_REGISTRY");
+
+        vm.startBroadcast(pk);
+        MarsTLD tld = new MarsTLD(REG);
+        vm.stopBroadcast();
+
+        console2.log("MarsTLD:", address(tld));
+    }
+}

--- a/mars-tld/scripts/02_apply_params_from_dot3.s.sol
+++ b/mars-tld/scripts/02_apply_params_from_dot3.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/IGlacierRegistry.sol";
+import "../contracts/MarsTLD.sol";
+
+contract ApplyParamsFromDot3 is Script {
+    function run() external {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address REG = vm.envAddress("GLACIER_REGISTRY");
+        address MARS = vm.envAddress("MARS_TLD"); // output from 01_deploy_mars
+
+        bytes32 DOT3 = keccak256(abi.encodePacked(".3"));
+        ( ,address resolver,address controller,address fee,address comp,address tba) =
+            IGlacierRegistry(REG).tldInfo(DOT3);
+
+        vm.startBroadcast(pk);
+        MarsTLD(MARS).applyParams(resolver, controller, fee, comp, tba);
+        vm.stopBroadcast();
+
+        console2.log("Applied params from .3 to .mars");
+    }
+}

--- a/mars-tld/scripts/03_mint_subdomain.s.sol
+++ b/mars-tld/scripts/03_mint_subdomain.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/IControllerLike.sol";
+
+contract MintSubdomain is Script {
+    function run() external {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address CONTROLLER = vm.envAddress("CONTROLLER");
+        address TO = vm.envAddress("RECIPIENT");
+        string memory LABEL = vm.envString("LABEL"); // e.g., "dao"
+
+        vm.startBroadcast(pk);
+        uint256 tokenId = IControllerLike(CONTROLLER).mint(TO, LABEL, ".mars");
+        vm.stopBroadcast();
+
+        console2.log("Minted:", tokenId);
+    }
+}

--- a/mars-tld/scripts/04_one_shot_deploy.s.sol
+++ b/mars-tld/scripts/04_one_shot_deploy.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/MarsTLD.sol";
+import "../contracts/IGlacierRegistry.sol";
+import "../contracts/IControllerLike.sol";
+
+contract OneShotMars is Script {
+    function run() external {
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address REG = vm.envAddress("GLACIER_REGISTRY");
+        bytes32 DOT3 = keccak256(abi.encodePacked(".3"));
+
+        vm.startBroadcast(pk);
+        MarsTLD tld = new MarsTLD(REG);
+
+        (, address resolver, address controller, address fee, address comp, address tba) =
+            IGlacierRegistry(REG).tldInfo(DOT3);
+
+        tld.applyParams(resolver, controller, fee, comp, tba);
+
+        address deployer = vm.addr(pk);
+        IControllerLike ctl = IControllerLike(controller);
+        string[10] memory labels = [
+            "dao",
+            "gov",
+            "vault",
+            "id",
+            "oracle",
+            "court",
+            "bridge",
+            "rwa",
+            "energy",
+            "carbon"
+        ];
+        for (uint256 i = 0; i < labels.length; i++) {
+            ctl.mint(deployer, labels[i], ".mars");
+        }
+        vm.stopBroadcast();
+
+        console2.log("MarsTLD:", address(tld));
+    }
+}

--- a/mars-tld/scripts/deploy.sh
+++ b/mars-tld/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: PRIVATE_KEY, RPC_URL, GLACIER_REGISTRY
+forge script scripts/01_deploy_mars.s.sol:DeployMars \
+  --rpc-url "$RPC_URL" --broadcast -vvvv
+
+# After deploy, export the MARS_TLD from the previous console log:
+# export MARS_TLD=0x...  (paste it)
+forge script scripts/02_apply_params_from_dot3.s.sol:ApplyParamsFromDot3 \
+  --rpc-url "$RPC_URL" --broadcast -vvvv


### PR DESCRIPTION
## Summary
- implement MarsTLD contract matching .3 TLD pattern
- add scripts to deploy .mars, copy parameters from .3, and mint subdomains
- include metadata, env template, and Foundry config for .mars
- add superstack task spec and one-shot Foundry deployment script
- switch to generic RPC_URL env variable in docs and scripts
- document Foundry install, add Makefile, and rename one-shot deploy script

## Testing
- `npx solcjs --bin mars-tld/contracts/MarsTLD.sol -o /tmp/mars-build`
- `forge build` *(command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a0c42e08329af9bc8e45f7123e9