### PR TITLE
Add role-based claim controls for coverage vault

### DIFF
--- a/contracts/Coverage.sol
+++ b/contracts/Coverage.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+/// @title Simple coverage vault that pays claims from ETH balance
+/// @notice Coverage can only be issued and claims paid by accounts with the TREASURY_ROLE
+contract Coverage is Ownable, AccessControl {
+    bytes32 public constant TREASURY_ROLE = keccak256("TREASURY_ROLE");
+
+    // Track how much coverage each policy holder has
+    mapping(address => uint256) public coverageOf;
+
+    constructor(address owner) Ownable(owner) {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+        _grantRole(TREASURY_ROLE, owner);
+    }
+
+    /// @notice Issue coverage to a policy holder
+    /// @param to Address receiving coverage
+    /// @param amount Coverage amount to credit
+    function issueCoverage(address to, uint256 amount) external onlyRole(TREASURY_ROLE) {
+        coverageOf[to] += amount;
+    }
+
+    /// @notice Pay an insurance claim to a policy holder
+    /// @param to Address receiving the claim payment
+    /// @param amount Amount of ETH to pay
+    function payClaim(address to, uint256 amount) external onlyRole(TREASURY_ROLE) {
+        require(coverageOf[to] >= amount, "not covered");
+        require(address(this).balance >= amount, "insufficient vault balance");
+        coverageOf[to] -= amount;
+        (bool ok, ) = payable(to).call{value: amount}("");
+        require(ok, "transfer failed");
+    }
+
+    /// @notice Allow the contract to receive ETH to fund claims
+    receive() external payable {}
+}
+

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -1,0 +1,49 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Coverage", function () {
+  let coverage, owner, treasury, user, attacker;
+  beforeEach(async function () {
+    [owner, treasury, user, attacker] = await ethers.getSigners();
+    const Coverage = await ethers.getContractFactory("Coverage");
+    coverage = await Coverage.deploy(owner.address);
+    await coverage.deployed();
+    const TREASURY_ROLE = await coverage.TREASURY_ROLE();
+    await coverage.connect(owner).grantRole(TREASURY_ROLE, treasury.address);
+  });
+
+  it("treasury can issue coverage and pay claim when funded", async function () {
+    const amount = ethers.utils.parseEther("1");
+    await coverage.connect(treasury).issueCoverage(user.address, amount);
+    await owner.sendTransaction({ to: coverage.address, value: amount });
+
+    const before = await ethers.provider.getBalance(user.address);
+    await coverage.connect(treasury).payClaim(user.address, amount);
+    const after = await ethers.provider.getBalance(user.address);
+
+    expect(after.sub(before)).to.equal(amount);
+    expect(await coverage.coverageOf(user.address)).to.equal(0);
+  });
+
+  it("non-treasury cannot issue coverage", async function () {
+    await expect(
+      coverage.connect(attacker).issueCoverage(user.address, 1)
+    ).to.be.reverted;
+  });
+
+  it("non-treasury cannot pay claim", async function () {
+    await expect(
+      coverage.connect(attacker).payClaim(user.address, 1)
+    ).to.be.reverted;
+  });
+
+  it("reverts when vault balance insufficient", async function () {
+    const amount = ethers.utils.parseEther("1");
+    await coverage.connect(treasury).issueCoverage(user.address, amount);
+
+    await expect(
+      coverage.connect(treasury).payClaim(user.address, amount)
+    ).to.be.revertedWith("insufficient vault balance");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Coverage contract with AccessControl + Ownable
- restrict issueCoverage and payClaim to treasury role and ensure vault funding
- test authorized and unauthorized claim flows

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68ae04cc1958832993ec1ef447f26671