### PR TITLE
Add access control to bond contracts

### DIFF
--- a/contracts/BondManager.sol
+++ b/contracts/BondManager.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./BondToken.sol";
+
+contract BondManager is AccessControl {
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+    address public immutable treasury;
+    BondToken public immutable bondToken;
+
+    constructor(address _treasury, address _bondToken) {
+        treasury = _treasury;
+        bondToken = BondToken(_bondToken);
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    function issueBond(address to, uint256 amount) external {
+        require(msg.sender == treasury || hasRole(MANAGER_ROLE, msg.sender), "Unauthorized");
+        // bond issuance logic omitted
+    }
+
+    function redeemBond(uint256 amount) external {
+        require(msg.sender == treasury || hasRole(MANAGER_ROLE, msg.sender), "Unauthorized");
+        // bond redemption logic omitted
+    }
+
+    function payCoupon(address to, uint256 amount) external {
+        require(msg.sender == treasury || hasRole(MANAGER_ROLE, msg.sender), "Unauthorized");
+        bondToken.payCoupon(to, amount);
+    }
+}
+

--- a/contracts/BondToken.sol
+++ b/contracts/BondToken.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract BondToken is ERC20, AccessControl {
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+    address public immutable treasury;
+
+    event CouponPaid(address indexed to, uint256 amount);
+
+    constructor(address _treasury) ERC20("BondToken", "BND") {
+        treasury = _treasury;
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    function payCoupon(address to, uint256 amount) external {
+        require(msg.sender == treasury || hasRole(MANAGER_ROLE, msg.sender), "Unauthorized");
+        emit CouponPaid(to, amount);
+    }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.3",
         "@openzeppelin/contracts": "^5.4.0",
+        "chai": "^6.0.1",
+        "chai-as-promised": "^8.0.2",
         "ethers": "^5.8.0",
         "hardhat": "^2.26.1",
         "solc": "^0.8.30"
@@ -1541,6 +1543,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.0.1.tgz",
+      "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "check-error": "^2.1.1"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 7"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1556,6 +1581,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@openzeppelin/contracts": "^5.4.0",
+    "chai": "^6.0.1",
+    "chai-as-promised": "^8.0.2",
     "ethers": "^5.8.0",
     "hardhat": "^2.26.1",
     "solc": "^0.8.30"

--- a/test/bondAccess.test.js
+++ b/test/bondAccess.test.js
@@ -1,0 +1,75 @@
+const chai = require("chai");
+const { expect } = chai;
+chai.use(require("chai-as-promised").default);
+const { ethers } = require("hardhat");
+const solc = require("solc");
+const fs = require("fs");
+const path = require("path");
+
+function compileContracts() {
+  const basePath = path.join(__dirname, "..");
+
+  function findImports(importPath) {
+    if (importPath.startsWith("@")) {
+      const fullPath = path.join(basePath, "node_modules", importPath);
+      return { contents: fs.readFileSync(fullPath, "utf8") };
+    }
+    const fullPath = path.join(basePath, "contracts", importPath);
+    return { contents: fs.readFileSync(fullPath, "utf8") };
+  }
+
+  const input = {
+    language: "Solidity",
+    sources: {
+      "BondManager.sol": {
+        content: fs.readFileSync(path.join(basePath, "contracts", "BondManager.sol"), "utf8"),
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImports }));
+  const manager = output.contracts["BondManager.sol"]["BondManager"];
+  const token = output.contracts["BondToken.sol"]["BondToken"];
+  return { manager, token };
+}
+
+describe("Bond access control", function () {
+  let treasury, other, bondToken, bondManager;
+
+  beforeEach(async function () {
+    [treasury, other] = await ethers.getSigners();
+    const { manager, token } = compileContracts();
+
+    const BondTokenFactory = new ethers.ContractFactory(token.abi, token.evm.bytecode.object, treasury);
+    bondToken = await BondTokenFactory.deploy(treasury.address);
+    await bondToken.deployed();
+
+    const BondManagerFactory = new ethers.ContractFactory(manager.abi, manager.evm.bytecode.object, treasury);
+    bondManager = await BondManagerFactory.deploy(treasury.address, bondToken.address);
+    await bondManager.deployed();
+  });
+
+  it("issueBond unauthorized", async function () {
+    await expect(bondManager.connect(other).issueBond(other.address, 1)).to.be.rejectedWith("Unauthorized");
+  });
+
+  it("redeemBond unauthorized", async function () {
+    await expect(bondManager.connect(other).redeemBond(1)).to.be.rejectedWith("Unauthorized");
+  });
+
+  it("payCoupon unauthorized", async function () {
+    await expect(bondManager.connect(other).payCoupon(other.address, 1)).to.be.rejectedWith("Unauthorized");
+  });
+
+  it("BondToken payCoupon unauthorized", async function () {
+    await expect(bondToken.connect(other).payCoupon(other.address, 1)).to.be.rejectedWith("Unauthorized");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add AccessControl-managed roles to BondManager and BondToken
- restrict bond issuance, redemption, and coupon payments to treasury or manager
- test that unauthorized calls to bond functions revert

## Testing
- `HARDHAT_COMPILER_DOWNLOADS=local npx hardhat test --no-compile`

------
https://chatgpt.com/codex/tasks/task_e_68ae04c87cbc83299722c4a0acffc9e0