### PR TITLE
Add access control to registries with tests

### DIFF
--- a/contracts/ForwardingRegistry.sol
+++ b/contracts/ForwardingRegistry.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Registry of trusted forwarder addresses
+/// @notice Only the owner may approve or revoke forwarders
+contract ForwardingRegistry is Ownable {
+    mapping(address => bool) public isForwarderApproved;
+
+    event ForwarderApproved(address indexed forwarder);
+    event ForwarderRevoked(address indexed forwarder);
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function approveForwarder(address forwarder) external onlyOwner {
+        isForwarderApproved[forwarder] = true;
+        emit ForwarderApproved(forwarder);
+    }
+
+    function revokeForwarder(address forwarder) external onlyOwner {
+        isForwarderApproved[forwarder] = false;
+        emit ForwarderRevoked(forwarder);
+    }
+}
+

--- a/contracts/StakedERC20Registry.sol
+++ b/contracts/StakedERC20Registry.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Registry for approved staked ERC20 tokens
+/// @notice Allows the owner to approve or revoke tokens
+contract StakedERC20Registry is Ownable {
+    mapping(address => bool) public approved;
+
+    event Approved(address indexed token);
+    event Revoked(address indexed token);
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function approve(address token) external onlyOwner {
+        approved[token] = true;
+        emit Approved(token);
+    }
+
+    function revoke(address token) external onlyOwner {
+        approved[token] = false;
+        emit Revoked(token);
+    }
+}
+

--- a/test/ForwardingRegistry.test.js
+++ b/test/ForwardingRegistry.test.js
@@ -1,0 +1,26 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ForwardingRegistry", function () {
+  let owner, user, registry;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory("ForwardingRegistry");
+    registry = await Registry.deploy(owner.address);
+  });
+
+  it("non-owner cannot approve forwarders", async function () {
+    await expect(
+      registry.connect(user).approveForwarder(user.address)
+    ).to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount");
+  });
+
+  it("non-owner cannot revoke forwarders", async function () {
+    // first approve as owner so revoke is meaningful
+    await registry.approveForwarder(user.address);
+    await expect(
+      registry.connect(user).revokeForwarder(user.address)
+    ).to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount");
+  });
+});

--- a/test/StakedERC20Registry.test.js
+++ b/test/StakedERC20Registry.test.js
@@ -1,0 +1,25 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("StakedERC20Registry", function () {
+  let owner, user, registry;
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory("StakedERC20Registry");
+    registry = await Registry.deploy(owner.address);
+  });
+
+  it("non-owner cannot approve tokens", async function () {
+    await expect(
+      registry.connect(user).approve(user.address)
+    ).to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount");
+  });
+
+  it("non-owner cannot revoke tokens", async function () {
+    await registry.approve(user.address);
+    await expect(
+      registry.connect(user).revoke(user.address)
+    ).to.be.revertedWithCustomError(registry, "OwnableUnauthorizedAccount");
+  });
+});


### PR DESCRIPTION
## Summary
- add `Ownable` to `ForwardingRegistry` and `StakedERC20Registry`
- restrict `approve*` and `revoke*` functions to owner
- add tests covering unauthorized access

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68ae04c554888329ba8221064d2c0dd3