### PR TITLE
Add .mars stack prompt and Foundry deploy script

### DIFF
--- a/.claude-flow/tasks/.mars-superstack.md
+++ b/.claude-flow/tasks/.mars-superstack.md
@@ -1,0 +1,126 @@
+Here’s a **copy-paste master prompt** you can drop into Claude Flow (or any builder agent) to generate the **.mars** sovereign TLD stack: soulbound ERC-6551 wallets, vaults, token minting, and RWA rails — end-to-end.
+
+```
+SYSTEM ROLE
+You are the Lead Architect AI for the .mars sovereign namespace under the Unykorn/GlacierMint stack. Build a production-grade, compliance-aware, chain-agnostic system that mints and governs .mars TLD + subdomains and powers soulbound ERC-6551 wallets, vault vaults, token minting (utility, governance, securities), and real-world asset onboarding. Ship an auditable, runnable repo with scripts, tests, and docs.
+
+PRIMARY OBJECTIVE
+Design and scaffold the most capable yet minimal-to-run .mars stack that an operator can deploy in hours, then scale to institutions. Optimize for correctness, security, composability, and compliance.
+
+OUTPUT REQUIREMENTS
+• A complete monorepo with:
+  - /contracts (Solidity): TLD, Controller, Resolver, Registry adapter, ERC-6551 account + registry, Vaults, Token factories, Compliance modules, Oracle adapters
+  - /deploy (Foundry/Hardhat scripts): one-shot deployment, param sync from .3, subdomain reserves (dao.mars, gov.mars, vault.mars, id.mars)
+  - /packages/sdk (TypeScript): typed client (ethers + viem), subdomain mint, vault ops, token mint, compliance attest, PoR hooks
+  - /agents (JS/TS): FlowAgent, ComplianceAgent, OracleAgent (Chainlink + internal), RWA Intake Agent, MRV Agent for sustainability assets
+  - /apps/portal (React+Vite): operator console (TLD admin, registry sync, mint flows, KYC/KYB checklist, PoR dashboard)
+  - /docs: ARCHITECTURE.md, COMPLIANCE.md, RWA-PLAYBOOK.md, RUNBOOK.md, API.md
+  - CI: Foundry tests, slither/solhint, gas snapshots, typechain build, coverage gate
+• Provide env templates, Makefile, and a single command to deploy on Polygon/Ethereum testnet, then mainnet.
+
+SCOPE & MODULES
+1) TLD & Registry
+   - GlacierMint-compatible `.mars` TLD (ERC-721 root), hash keccak256(".mars")
+   - Mirror all params from `.3` (resolver, controller, fee model, compliance module, 6551 impl)
+   - Subdomain NFTs (ERC-721) with TokenBound (ERC-6551) accounts auto-bound at mint
+   - Leasing + renewal (annual), grace periods, reserve list, premium pricing hooks
+
+2) Identity & Wallets (Soulbound “bad-ass” 6551)
+   - ERC-6551 minimal proxy accounts; enforce SOULBOUND on TLD + identity NFTs (non-transferable except via guardian recover)
+   - Guardian/social recovery (EIP-4337 compatible), session keys, rate-limited withdrawals, allowlist ops
+   - Roles: OWNER, OPERATOR, COMPLIANCE_OFFICER, ORACLE_SIGNER
+
+3) Vaults & Asset Containers
+   - ERC-6551 “VaultAccount” template to custody tokens, RWAs, receipts, sub-NFTs
+   - Plug-in modules: FeeRouter, RoyaltyRouter (ERC-2981), TaxWithholding, Freeze/Seize (court order or DAO vote), TimeLock
+
+4) Token Factories
+   - Utility/Gov: ERC-20 & 20Permit; optional Fee-On-Transfer with compliance hooks
+   - Multi-asset: ERC-1155 for baskets (e.g., energy credits, certificates)
+   - Securities: ERC-1400/3643-style partitioned shares (whitelist, tranches, lock-up, transfer restrictions, investor caps)
+   - Bond/Sukuk templates: coupon schedules, profit-sharing, asset-linked payouts, Sharia screens pluggable
+
+5) RWA Onboarding
+   - Intake schema (JSON): identity, asset docs, appraisal, liens, jurisdiction, ESG/MRV data
+   - IPFS/Arweave notarization; PGP signature bundle; on-chain CID anchors
+   - Chainlink Proof-of-Reserves adapter + custom OracleAgent for off-chain attestations
+   - Title/escrow flows: mint RWA-NFT → wrap in ERC-6551 vault → issue fractions (ERC-1400/1155) with compliance gating
+
+6) Compliance Layer (GLOBAL)
+   - RegLogic module: KYC/KYB attest (soulbound badges), FATF Travel Rule fields, sanctions lists, geo-fencing
+   - ISO 20022 event emitters (PACS/CAMT subsets) as on-chain logs + off-chain webhooks
+   - Transfer pre-checks: ruleSets (US Reg D/Reg S, EU MiCA, UK, CH), investor eligibility, holding periods
+   - Audit trail export (JSON/CSV/PDF) with deterministic hashes
+
+7) Interop & Settlement
+   - LayerZero or Axelar bridge adapter with compliance pre-flight
+   - Oracle adapters (Chainlink/Pyth) for FX, commodities, energy
+   - Optional CBDC/RLN bridge stub interface
+
+8) Governance
+   - DAO contracts: TLD policy votes (fees, reserves, compliance rules), emergency pause, court-order executor
+   - Snapshot-compatible strategy + on-chain timelock executor
+
+9) Security & Quality
+   - AccessControl, Pausable, ReentrancyGuard; upgradability via UUPS with guardian veto
+   - Full Foundry tests: unit + invariant + fuzz; minimal reproducible gas profile
+
+API & COMMANDS (OPERATOR UX)
+• make up
+  - installs toolchain (node, foundry), builds contracts, generates typechain
+• make test
+  - runs slither/solhint + foundry tests + coverage
+• make devnet
+  - spins local chain, deploys full stack, seeds sample assets (.env overrides)
+• make deploy-testnet / make deploy-mainnet
+  - runs one-shot scripts: deploy TLD → apply params from .3 → reserve names → publish CIDs → print addresses
+• sdk usage examples in /examples: mint subdomain, mint vault, mint token (20/1155/1400), attach compliance, publish PoR
+
+KEY INTERFACES (Solidity—exact signatures the repo must implement)
+• ITLDLike.applyParams(address resolver, address controller, address feeModel, address compliance, address tbaImpl)
+• IController.mint(address to, string label, string tld) returns (uint256 tokenId)
+• ISubdomainResolver.setRecords(tokenId, bytes[] records)
+• ICompliance.checkTransfer(address from, address to, address asset, uint256 id, uint256 amount) returns (bool ok, bytes32 reason)
+• IVaultAccount.execute(bytes targetCall) restricted(OPERATOR | OWNER | POLICY)
+• IOracleAgent.attest(bytes32 schemaId, bytes payload, bytes signature) returns (bytes32 attestationId)
+• IProofOfReserves.report(bytes32 assetId, uint256 value, uint256 timestamp, bytes oracleSig)
+
+CONFIG VARIABLES (fill from .env)
+GLACIER_REGISTRY=0x...
+DOT3_TLD=0x...(for param mirroring)
+POLYGON_RPC_URL=...
+ETH_RPC_URL=...
+CHAINLINK_FEEDS={fx:..., commodity:..., energy:...}
+LAYERZERO_ENDPOINT=0x...
+PGP_PUBKEY=-----BEGIN PGP PUBLIC KEY BLOCK-----...
+
+NON-FUNCTIONAL TARGETS
+• Gas-aware design; modular hooks (minimal overhead when disabled)
+• Deterministic build; reproducible deployments with salts
+• Clean separation: core vs policy vs jurisdiction modules
+
+DELIVERABLE CHECKLIST
+[ ] Deployable contracts with addresses saved to /deploy/addresses.json
+[ ] One-shot deployment script succeeds on testnet (print all addresses)
+[ ] 90%+ unit coverage; ≥10 invariant tests; ≥5 fuzz tests per critical module
+[ ] CI green: lint, typecheck, tests, coverage, build
+[ ] Operator Portal runs: can reserve subdomains, mint identity, mint vault, mint tokens, attach compliance, publish PoR
+[ ] Docs: runbook for ops, architecture diagrams (mermaid), RWA onboarding playbook, API examples
+[ ] Security: list of assumptions/threats, admin keys & recovery plan, pause procedure
+
+STYLE & GUARDRAILS
+• Prefer OpenZeppelin contracts; explicit AccessControl roles
+• Upgradability via UUPS only when strictly necessary; otherwise immutable
+• All external calls checked; no tx-origin auth; events for every state change
+• Avoid custom assembly unless justified with tests and comments
+
+INITIAL RESERVED SUBDOMAINS
+dao.mars, gov.mars, vault.mars, id.mars, oracle.mars, court.mars, bridge.mars, rwa.mars, energy.mars, carbon.mars
+
+END STATE
+Return a fully scaffolded repo (tree + files) ready to `make devnet` and `make deploy-testnet`. Include seed scripts that mint:
+• a soulbound identity (id.mars) bound to a 6551 wallet,
+• a vault.mars ERC-6551 account holding a sample RWA-NFT,
+• a governance ERC-20 and an ERC-1400 security with Reg D rules,
+• proof-of-reserves sample attestation wired to the dashboard.
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "contracts"
+script = "script"
+out = "out"
+libs = ["node_modules"]
+remappings = ["@openzeppelin/=node_modules/@openzeppelin/"]
+solc_version = "0.8.20"

--- a/script/DeployMars.s.sol
+++ b/script/DeployMars.s.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../contracts/VTV.sol";
+
+contract DeployMars is Script {
+    function run() external {
+        vm.startBroadcast();
+        new VTV();
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## Summary
- add `.mars` superstack prompt for Claude Flow
- introduce Foundry configuration and one-shot deployment script for VTV

## Testing
- `npx hardhat test` *(fails: couldn't download compiler version list)*
- `forge --version` *(command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adca82f0ac8329a9c4087775d8fefc