### PR TITLE
Add jurisdiction-aware WaterFlow contract

### DIFF
--- a/contracts/water/RegLogic.sol
+++ b/contracts/water/RegLogic.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title RegLogic
+/// @notice Minimal jurisdiction validation logic for demonstration purposes.
+contract RegLogic {
+    mapping(address => bool) public permitted;
+
+    /// @notice Allows configuration of whether an address passes jurisdictional checks.
+    /// @param user The address to configure.
+    /// @param status Whether the address is permitted.
+    function setPermission(address user, bool status) external {
+        permitted[user] = status;
+    }
+
+    /// @notice Validates whether a user is permitted in the current jurisdiction.
+    /// @param user The address to validate.
+    /// @return True if the user is permitted, false otherwise.
+    function validate(address user) external view returns (bool) {
+        return permitted[user];
+    }
+}
+

--- a/contracts/water/WaterFlow.sol
+++ b/contracts/water/WaterFlow.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IRegLogic {
+    function validate(address user) external view returns (bool);
+}
+
+/// @title WaterFlow
+/// @notice Tracks water allocations and usage with jurisdictional validation.
+contract WaterFlow is Ownable {
+    IRegLogic public regLogic;
+    address public regulator;
+
+    mapping(address => uint256) public allocations;
+    mapping(address => uint256) public usage;
+    mapping(address => uint256) public balances;
+
+    /// @param _regLogic Address of the regulatory logic contract.
+    /// @param _regulator Address allowed to report usage alongside the owner.
+    constructor(address _regLogic, address _regulator) Ownable(msg.sender) {
+        regLogic = IRegLogic(_regLogic);
+        regulator = _regulator;
+    }
+
+    modifier onlyAuthorized() {
+        require(msg.sender == regulator || msg.sender == owner(), "not authorized");
+        _;
+    }
+
+    /// @notice Records water usage for a user. Restricted to regulator or vault owner.
+    /// @param user Address of the user.
+    /// @param amount Amount of usage to report.
+    function reportUsage(address user, uint256 amount) external onlyAuthorized {
+        usage[user] += amount;
+    }
+
+    /// @notice Settles recorded usage against allocations with jurisdiction checks.
+    /// @param user Address of the user being settled.
+    function settleFlow(address user) external onlyAuthorized {
+        uint256 used = usage[user];
+        uint256 allocated = allocations[user];
+        require(used <= allocated, "usage exceeds allocation");
+        require(regLogic.validate(user), "jurisdiction invalid");
+        allocations[user] = allocated - used;
+        balances[user] += used;
+        usage[user] = 0;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce `WaterFlow` contract to track allocations and usage
- Restrict usage reporting to regulator or vault owner
- Validate jurisdiction via `RegLogic` before settling usage

## Testing
- `npx hardhat compile` *(fails: HH502 Couldn't download compiler version list)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0cfc314883298460c65a623e77f9