### PR TITLE
Add authorized logger role to AuditTrail

### DIFF
--- a/contracts/AuditTrail.sol
+++ b/contracts/AuditTrail.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract AuditTrail is AccessControl {
+    bytes32 public constant LOGGER_ROLE = keccak256("LOGGER_ROLE");
+
+    struct Record {
+        address user;
+        uint256 amount;
+        uint256 timestamp;
+    }
+
+    event TransactionLogged(address indexed user, uint256 amount, uint256 timestamp);
+
+    Record[] public records;
+
+    constructor(address admin) {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    function logTransaction(address user, uint256 amount) external onlyRole(LOGGER_ROLE) {
+        records.push(Record(user, amount, block.timestamp));
+        emit TransactionLogged(user, amount, block.timestamp);
+    }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.3",
         "@openzeppelin/contracts": "^5.4.0",
+        "chai": "^6.0.1",
         "ethers": "^5.8.0",
         "hardhat": "^2.26.1",
         "solc": "^0.8.30"
@@ -1539,6 +1540,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.0.1.tgz",
+      "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@openzeppelin/contracts": "^5.4.0",
+    "chai": "^6.0.1",
     "ethers": "^5.8.0",
     "hardhat": "^2.26.1",
     "solc": "^0.8.30"

--- a/test/AuditTrail.js
+++ b/test/AuditTrail.js
@@ -1,0 +1,59 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const path = require("path");
+const fs = require("fs");
+const solc = require("solc");
+
+function findImports(importPath) {
+  try {
+    const resolvedPath = path.join(__dirname, "..", "node_modules", importPath);
+    const contents = fs.readFileSync(resolvedPath, "utf8");
+    return { contents };
+  } catch (e) {
+    return { error: "File not found" };
+  }
+}
+
+function compileContract() {
+  const contractPath = path.join(__dirname, "..", "contracts", "AuditTrail.sol");
+  const source = fs.readFileSync(contractPath, "utf8");
+  const input = {
+    language: "Solidity",
+    sources: { "AuditTrail.sol": { content: source } },
+    settings: { outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } } },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImports }));
+  return output.contracts["AuditTrail.sol"].AuditTrail;
+}
+
+describe("AuditTrail", function () {
+  let auditTrail, LOGGER_ROLE, owner, logger, other;
+
+  beforeEach(async function () {
+    [owner, logger, other] = await ethers.getSigners();
+    const artifact = compileContract();
+    const factory = new ethers.ContractFactory(artifact.abi, artifact.evm.bytecode.object, owner);
+    auditTrail = await factory.deploy(owner.address);
+    await auditTrail.deployed();
+    LOGGER_ROLE = await auditTrail.LOGGER_ROLE();
+  });
+
+  it("allows addresses with LOGGER_ROLE to log transactions", async function () {
+    await auditTrail.grantRole(LOGGER_ROLE, logger.address);
+    await auditTrail.connect(logger).logTransaction(other.address, 123);
+    const record = await auditTrail.records(0);
+    expect(record.user).to.equal(other.address);
+    expect(record.amount.toString()).to.equal("123");
+  });
+
+  it("reverts when non-authorized address attempts to log", async function () {
+    let failed = false;
+    try {
+      await auditTrail.connect(other).logTransaction(other.address, 1, { gasLimit: 100000 });
+    } catch (err) {
+      failed = true;
+    }
+    expect(failed).to.equal(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add AuditTrail contract with `LOGGER_ROLE` and role-protected `logTransaction`
- configure tests to ensure only accounts with `LOGGER_ROLE` can log
- include chai as dev dependency for running tests

## Testing
- `npx hardhat test --no-compile`


------
https://chatgpt.com/codex/tasks/task_e_68ae04c6788c8329a17c5720317435da