### PR TITLE
feat: limit investor count

### DIFF
--- a/contracts/FTHBaseToken.sol
+++ b/contracts/FTHBaseToken.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+abstract contract FTHBaseToken is ERC20, Ownable {
+    uint256 public investorCount;
+    uint256 public constant maxInvestors = 200;
+
+    event MaxInvestorsReached(uint256 maxInvestors);
+
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) Ownable(msg.sender) {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 amount) internal override {
+        if (from == to) {
+            super._update(from, to, amount);
+            return;
+        }
+
+        bool fromWillBeZero = from != address(0) && balanceOf(from) == amount;
+        bool toIsNew = to != address(0) && balanceOf(to) == 0;
+
+        if (toIsNew && !fromWillBeZero) {
+            require(investorCount < maxInvestors, "Investor limit reached");
+            unchecked {
+                investorCount++;
+            }
+            if (investorCount == maxInvestors) {
+                emit MaxInvestorsReached(maxInvestors);
+            }
+        }
+
+        super._update(from, to, amount);
+
+        if (fromWillBeZero && !toIsNew) {
+            unchecked {
+                investorCount--;
+            }
+        }
+    }
+}
+

--- a/contracts/FTHDebtToken.sol
+++ b/contracts/FTHDebtToken.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./FTHBaseToken.sol";
+
+contract FTHDebtToken is FTHBaseToken {
+    constructor() FTHBaseToken("FTHDebtToken", "FTHD") {}
+}
+

--- a/contracts/FTHEquityToken.sol
+++ b/contracts/FTHEquityToken.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./FTHBaseToken.sol";
+
+contract FTHEquityToken is FTHBaseToken {
+    constructor() FTHBaseToken("FTHEquityToken", "FTEQ") {}
+}
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains example Solidity smart contracts for an NFT marketplace with staking functionality. The contracts demonstrate how to list ERC‑731 tokens for sale and allow holders to stake their NFTs to earn rewards.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "keywords": [],
   "author": "",

--- a/test/FTHInvestorLimit.js
+++ b/test/FTHInvestorLimit.js
@@ -1,0 +1,43 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+for (const name of ["FTHEquityToken", "FTHDebtToken"]) {
+  describe(name, function () {
+    let owner, investor1, investor2, token;
+    this.timeout(0);
+
+    beforeEach(async function () {
+      [owner, investor1, investor2] = await ethers.getSigners();
+      const Token = await ethers.getContractFactory(name);
+      token = await Token.deploy();
+      await token.deployed?.();
+    });
+
+    it("enforces max investors on mint", async function () {
+      for (let i = 0; i < 199; i++) {
+        const wallet = ethers.Wallet.createRandom();
+        await token.mint(wallet.address, 1);
+      }
+      await expect(token.mint(investor1.address, 1))
+        .to.emit(token, "MaxInvestorsReached")
+        .withArgs(200);
+      await expect(token.mint(ethers.Wallet.createRandom().address, 1)).to.be.revertedWith(
+        "Investor limit reached"
+      );
+    });
+
+    it("enforces max investors on transfer", async function () {
+      for (let i = 0; i < 199; i++) {
+        const wallet = ethers.Wallet.createRandom();
+        await token.mint(wallet.address, 1);
+      }
+      await token.mint(investor1.address, 2);
+      await expect(token.connect(investor1).transfer(investor2.address, 1)).to.be.revertedWith(
+        "Investor limit reached"
+      );
+      await token.connect(investor1).transfer(investor2.address, 2);
+      expect(await token.investorCount()).to.equal(200);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add base token with investor tracking and 200 investor limit
- implement FTHEquityToken and FTHDebtToken using base token
- test and configure investor limit enforcement

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68aacef341008329a4dc95eeb4cbe6d0