### PR TITLE
Add Gigagas contracts, tests and Foundry config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 .env
+lib/

--- a/contracts/AgglayerBridge.sol
+++ b/contracts/AgglayerBridge.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+contract AgglayerBridge {
+    IERC20 public token;
+    address public owner;
+
+    event Deposited(address indexed user, uint256 amount, string destinationChain, address recipient);
+    event Withdrawn(address indexed user, uint256 amount);
+
+    constructor(address _token) {
+        token = IERC20(_token);
+        owner = msg.sender;
+    }
+
+    function deposit(uint256 amount, string calldata destinationChain, address recipient) external {
+        require(amount > 0, "Zero deposit");
+        token.transferFrom(msg.sender, address(this), amount);
+        emit Deposited(msg.sender, amount, destinationChain, recipient);
+    }
+
+    function withdraw(uint256 amount) external {
+        require(msg.sender == owner, "Only owner");
+        token.transfer(owner, amount);
+        emit Withdrawn(owner, amount);
+    }
+}

--- a/contracts/BatchProcessor.sol
+++ b/contracts/BatchProcessor.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract BatchProcessor {
+    address public owner;
+    uint256 public maxBatchSize;
+
+    event BatchExecuted(address indexed executor, uint256 txCount);
+
+    constructor(uint256 _maxBatchSize) {
+        owner = msg.sender;
+        maxBatchSize = _maxBatchSize;
+    }
+
+    function executeBatch(address[] calldata targets, bytes[] calldata data) external {
+        require(targets.length == data.length, "Mismatched inputs");
+        require(targets.length <= maxBatchSize, "Batch too large");
+        for (uint256 i = 0; i < targets.length; i++) {
+            (bool ok, ) = targets[i].call(data[i]);
+            require(ok, "Tx failed");
+        }
+        emit BatchExecuted(msg.sender, targets.length);
+    }
+}

--- a/contracts/BatchTarget.sol
+++ b/contracts/BatchTarget.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract BatchTarget {
+    uint256 public value;
+
+    function setValue(uint256 v) external {
+        value = v;
+    }
+}

--- a/contracts/POLStaking.sol
+++ b/contracts/POLStaking.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+contract POLStaking {
+    IERC20 public polToken;
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public stakingTime;
+    uint256 public totalStaked;
+
+    event Staked(address indexed user, uint256 amount);
+    event Unstaked(address indexed user, uint256 amount);
+
+    constructor(address _polToken) {
+        polToken = IERC20(_polToken);
+    }
+
+    function stake(uint256 amount) external {
+        require(amount > 0, "Nothing to stake");
+        polToken.transferFrom(msg.sender, address(this), amount);
+        balances[msg.sender] += amount;
+        stakingTime[msg.sender] = block.timestamp;
+        totalStaked += amount;
+        emit Staked(msg.sender, amount);
+    }
+
+    function unstake(uint256 amount) external {
+        require(amount > 0 && balances[msg.sender] >= amount, "Invalid unstake");
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+        polToken.transfer(msg.sender, amount);
+        emit Unstaked(msg.sender, amount);
+    }
+}

--- a/contracts/ZkVerifier.sol
+++ b/contracts/ZkVerifier.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ZkVerifier {
+    address public verifier;
+
+    event ProofVerified(address indexed caller, bool valid);
+
+    constructor(address _verifier) {
+        verifier = _verifier;
+    }
+
+    function verifyProof(bytes calldata proof, bytes32[] calldata inputs) external returns (bool) {
+        bool valid = (proof.length > 0 && inputs.length > 0);
+        emit ProofVerified(msg.sender, valid);
+        return valid;
+    }
+}

--- a/foundry-test/Gigagas.t.sol
+++ b/foundry-test/Gigagas.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../contracts/POLStaking.sol";
+import "../contracts/AgglayerBridge.sol";
+import "../contracts/BatchProcessor.sol";
+import "../contracts/ZkVerifier.sol";
+
+contract TestToken is ERC20 {
+    constructor() ERC20("Test", "TST") {
+        _mint(msg.sender, 1e24);
+    }
+}
+
+contract Target {
+    uint256 public value;
+    function setValue(uint256 v) external { value = v; }
+}
+
+contract GigagasTest is Test {
+    TestToken token;
+    address user = address(0x1);
+
+    function setUp() public {
+        token = new TestToken();
+        token.transfer(user, 100 ether);
+    }
+
+    function testStakeAndUnstake() public {
+        POLStaking staking = new POLStaking(address(token));
+        vm.prank(user);
+        token.approve(address(staking), 50 ether);
+        vm.prank(user);
+        staking.stake(50 ether);
+        assertEq(staking.balances(user), 50 ether);
+        vm.prank(user);
+        staking.unstake(20 ether);
+        assertEq(staking.balances(user), 30 ether);
+    }
+
+    function testBridgeDepositWithdraw() public {
+        AgglayerBridge bridge = new AgglayerBridge(address(token));
+        vm.prank(user);
+        token.approve(address(bridge), 10 ether);
+        vm.prank(user);
+        bridge.deposit(10 ether, "dest", user);
+        bridge.withdraw(10 ether);
+        assertEq(token.balanceOf(address(bridge)), 0);
+    }
+
+    function testBatchProcessor() public {
+        BatchProcessor batch = new BatchProcessor(2);
+        Target t1 = new Target();
+        Target t2 = new Target();
+        address[] memory targets = new address[](2);
+        bytes[] memory data = new bytes[](2);
+        targets[0] = address(t1);
+        targets[1] = address(t2);
+        data[0] = abi.encodeWithSelector(t1.setValue.selector, 1);
+        data[1] = abi.encodeWithSelector(t2.setValue.selector, 2);
+        batch.executeBatch(targets, data);
+        assertEq(t1.value(), 1);
+        assertEq(t2.value(), 2);
+    }
+
+    function testZkVerifier() public {
+        ZkVerifier verifier = new ZkVerifier(address(this));
+        bytes memory proof = hex"01";
+        bytes32[] memory inputs = new bytes32[](1);
+        inputs[0] = bytes32(uint256(1));
+        bool valid = verifier.verifyProof(proof, inputs);
+        assertTrue(valid);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = 'contracts'
+test = 'foundry-test'
+libs = ['lib', 'node_modules']
+solc = '0.8.20'
+
+[dependencies]
+forge-std = { git = 'https://github.com/foundry-rs/forge-std', tag = 'v1.9.5' }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains example Solidity smart contracts for an NFT marketplace with staking functionality. The contracts demonstrate how to list ERC‑731 tokens for sale and allow holders to stake their NFTs to earn rewards.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test --no-compile"
   },
   "keywords": [],
   "author": "",

--- a/test/gigagas.js
+++ b/test/gigagas.js
@@ -1,0 +1,121 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const path = require("path");
+const fs = require("fs");
+const solc = require("solc");
+
+function findImports(importPath) {
+  try {
+    const resolvedPath = path.join(__dirname, "..", "node_modules", importPath);
+    const contents = fs.readFileSync(resolvedPath, "utf8");
+    return { contents };
+  } catch (e) {
+    return { error: "File not found" };
+  }
+}
+
+function compileContract(fileName, contractName) {
+  const contractPath = path.join(__dirname, "..", "contracts", fileName);
+  const source = fs.readFileSync(contractPath, "utf8");
+  const input = {
+    language: "Solidity",
+    sources: { [fileName]: { content: source } },
+    settings: { outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } } },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImports }));
+  return output.contracts[fileName][contractName];
+}
+
+describe("POLStaking", function () {
+  it("allows staking and unstaking", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const vtvArtifact = compileContract("VTV.sol", "VTV");
+    const VTVFactory = new ethers.ContractFactory(vtvArtifact.abi, vtvArtifact.evm.bytecode.object, owner);
+    const token = await VTVFactory.deploy();
+    await token.deployed();
+
+    const stakingArtifact = compileContract("POLStaking.sol", "POLStaking");
+    const StakingFactory = new ethers.ContractFactory(stakingArtifact.abi, stakingArtifact.evm.bytecode.object, owner);
+    const staking = await StakingFactory.deploy(token.address);
+    await staking.deployed();
+
+    await token.transfer(user.address, ethers.utils.parseEther("100"));
+    await token.connect(user).approve(staking.address, ethers.utils.parseEther("50"));
+
+    await staking.connect(user).stake(ethers.utils.parseEther("50"));
+    const balAfterStake = await staking.balances(user.address);
+    expect(balAfterStake.toString()).to.equal(ethers.utils.parseEther("50").toString());
+
+    await staking.connect(user).unstake(ethers.utils.parseEther("20"));
+    expect((await staking.balances(user.address)).toString()).to.equal(
+      ethers.utils.parseEther("30").toString()
+    );
+  });
+});
+
+describe("AgglayerBridge", function () {
+  it("handles deposits and withdrawals", async function () {
+    const [owner, user] = await ethers.getSigners();
+    const vtvArtifact = compileContract("VTV.sol", "VTV");
+    const VTVFactory = new ethers.ContractFactory(vtvArtifact.abi, vtvArtifact.evm.bytecode.object, owner);
+    const token = await VTVFactory.deploy();
+    await token.deployed();
+
+    const bridgeArtifact = compileContract("AgglayerBridge.sol", "AgglayerBridge");
+    const BridgeFactory = new ethers.ContractFactory(bridgeArtifact.abi, bridgeArtifact.evm.bytecode.object, owner);
+    const bridge = await BridgeFactory.deploy(token.address);
+    await bridge.deployed();
+
+    await token.transfer(user.address, ethers.utils.parseEther("10"));
+    await token.connect(user).approve(bridge.address, ethers.utils.parseEther("10"));
+
+    await bridge
+      .connect(user)
+      .deposit(ethers.utils.parseEther("10"), "polygon-zkevm", user.address);
+    await bridge.withdraw(ethers.utils.parseEther("10"));
+    expect((await token.balanceOf(bridge.address)).toString()).to.equal("0");
+  });
+});
+
+describe("BatchProcessor", function () {
+  it("executes batched calls", async function () {
+    const [owner] = await ethers.getSigners();
+    const batchArtifact = compileContract("BatchProcessor.sol", "BatchProcessor");
+    const BatchFactory = new ethers.ContractFactory(batchArtifact.abi, batchArtifact.evm.bytecode.object, owner);
+    const batch = await BatchFactory.deploy(2);
+    await batch.deployed();
+
+    const targetArtifact = compileContract("BatchTarget.sol", "BatchTarget");
+    const TargetFactory = new ethers.ContractFactory(targetArtifact.abi, targetArtifact.evm.bytecode.object, owner);
+    const target1 = await TargetFactory.deploy();
+    const target2 = await TargetFactory.deploy();
+    await target1.deployed();
+    await target2.deployed();
+
+    const txs = [
+      target1.interface.encodeFunctionData("setValue", [1]),
+      target2.interface.encodeFunctionData("setValue", [2])
+    ];
+    const targets = [target1.address, target2.address];
+
+    await batch.executeBatch(targets, txs);
+    expect((await target1.value()).toString()).to.equal("1");
+    expect((await target2.value()).toString()).to.equal("2");
+  });
+});
+
+describe("ZkVerifier", function () {
+  it("verifies proofs", async function () {
+    const [owner] = await ethers.getSigners();
+    const verifierArtifact = compileContract("ZkVerifier.sol", "ZkVerifier");
+    const VerifierFactory = new ethers.ContractFactory(verifierArtifact.abi, verifierArtifact.evm.bytecode.object, owner);
+    const verifier = await VerifierFactory.deploy(owner.address);
+    await verifier.deployed();
+
+    const proof = "0x1234";
+    const inputs = [ethers.constants.HashZero];
+    expect(
+      await verifier.callStatic.verifyProof(proof, inputs)
+    ).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add sample POL staking, bridge, batch processor and zk verifier contracts
- add hardhat tests for staking, bridge, batch and proof flows
- include foundry config and solidity tests scaffold

## Testing
- `npm test`
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af44636bfc832980a9c191f10716e7