### PR TITLE
docs: add audit and appraisal report

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ This repository contains example Solidity smart contracts for an NFT marketplace
    ```
 
 Copy `.env.template` to `.env` and fill in your RPC URL and deployer private key for network configuration.
+
+## Security & Audit
+
+See the [Audit and Appraisal Report](docs/AUDIT_AND_APPRAISAL.md) for security findings, compliance guidance, and value assessment.

--- a/docs/AUDIT_AND_APPRAISAL.md
+++ b/docs/AUDIT_AND_APPRAISAL.md
@@ -1,0 +1,36 @@
+# Audit and Appraisal Report
+
+## Executive Summary
+This assessment reviews the Unykorn smart-contract ecosystem, associated tooling, and operational controls. Our methodology combined automated analysis, manual code review, and inspection of deployment practices. Key findings indicate a modular architecture with strong adherence to open-source standards, though additional hardening of CI pipelines and continuous monitoring is recommended.
+
+## System Description
+Unykorn comprises Solidity contracts for token issuance, marketplace trading, staking, and subscription management. Hardhat drives compilation and testing, while scripts under `scripts/` and infrastructure definitions in `infra/` enable repeatable deployment. Assets are organized as a pnpm monorepo with separate packages for EVM and Solana components.
+
+## Security Audit
+- **Smart Contracts:** Contracts use OpenZeppelin libraries and follow upgradeable patterns. Static analysis and unit tests cover core functionality but formal verification is not yet integrated.
+- **CI/CD:** Automated testing is available through Hardhat. Integrating Slither, Foundry fuzzing, and cargo audit (for Solana code) would provide broader coverage.
+- **Dependencies:** NPM packages are locked via `package-lock.json`; periodic `npm audit` checks should be scheduled.
+- **Operational Controls:** Secrets are managed through environment variables. A dedicated runbook exists, yet access control reviews and incident response drills are advised.
+
+## Compliance & Governance
+The project targets compliance with common financial and messaging standards:
+- **KYC/AML:** No direct enforcement on-chain; off-chain onboarding is assumed and should integrate with regulated identity providers.
+- **ISO 20022:** Token and messaging formats can align with ISO 20022; mapping specifications are pending.
+- **UUPS Upgrade Policy:** Upgradeable proxies should require multi-signature authorization and timelocks to align with UUPS best practices.
+
+## Value Appraisal
+Unykorn enables rapid, cross-chain token launches and community engagement. Qualitatively, the platform lowers barriers for projects entering Web3. Quantitatively, revenue potential depends on marketplace fees and staking rewards; risks stem from smart-contract vulnerabilities and regulatory shifts.
+
+## Rating & Recommendations
+**Rating:** B (moderate risk)
+
+**Recommendations:**
+1. Expand automated analyses to include static, dynamic, and fuzz testing.
+2. Enforce multi-signature governance for upgrades and treasury operations.
+3. Maintain regular dependency audits and pin contract compiler versions.
+4. Develop metrics for user adoption and protocol revenue to refine value estimates.
+
+## Appendix
+- Prior security notes: [docs/SECURITY.md](SECURITY.md)
+- Coverage reports: pending; integrate `hardhat coverage` in CI.
+- External audit references: to be cataloged when engagements occur.


### PR DESCRIPTION
## Summary
- add comprehensive audit and appraisal report with security, compliance, and rating
- document new report in README under Security & Audit section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7357cf780832995a6d1959f464ae0